### PR TITLE
Missing Bash at top of file

### DIFF
--- a/_githooks/pre-commit
+++ b/_githooks/pre-commit
@@ -1,3 +1,4 @@
+#!/bin/bash
 # where the generated html and generated python files live
 script_folder="generated_python"
 html_folder="generated_html"


### PR DESCRIPTION
Missing #!/bin/bash at the top of the file which prevents github hook from being executed.